### PR TITLE
WIP update floki and move html escaping to HtmlEntities

### DIFF
--- a/lib/strip_js.ex
+++ b/lib/strip_js.ex
@@ -100,7 +100,7 @@ defmodule StripJs do
       ""
 
       iex> StripJs.clean_html("&lt;script&gt; console.log('oh heck'); &lt;/script&gt;")
-      "&lt;script&gt; console.log('oh heck'); &lt;/script&gt;"  ## HTML entity attack didn't work
+      "&lt;script&gt; console.log(&apos;oh heck&apos;); &lt;/script&gt;"  ## HTML entity attack didn't work
   """
   @spec clean_html(String.t, opts) :: String.t
   def clean_html(html, opts \\ []) when is_binary(html) do
@@ -206,7 +206,7 @@ defmodule StripJs do
       String.starts_with?(attr, "on") ->
         acc  # remove on* handlers entirely
       :else ->
-        [{attr, value |> escape_quotes |> html_escape} | acc]
+        [{attr, value |> html_escape} | acc]
     end
   end
 
@@ -214,17 +214,8 @@ defmodule StripJs do
   ## Performs good-enough HTML escaping to prevent HTML entity attacks.
   @spec html_escape(String.t) :: String.t
   defp html_escape(html) do
-    html
-    |> String.replace("&", "&amp;")
-    |> String.replace("<", "&lt;")
-    |> String.replace(">", "&gt;")
+    HtmlEntities.encode(html)
   end
-
-  defp escape_quotes(html) do
-    html
-    |> String.replace("\"", "&quot;")
-  end
-
 
   ## Parses the given HTML into an `t:html_tree/0` structure.
   @spec parse_html(String.t, opts) :: html_tree
@@ -234,6 +225,6 @@ defmodule StripJs do
   ## Converts HTML tree to string.
   @spec to_html(html_tree) :: String.t
   defp to_html(tree) when is_binary(tree), do: tree
-  defp to_html(tree), do: tree |> Floki.raw_html
+  defp to_html(tree), do: tree |> Floki.raw_html(encode: false)
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule StripJs.Mixfile do
   def project do
     [
       app: :strip_js,
-      version: "0.9.2",
+      version: "0.10.0",
       description: "Strip JavaScript from HTML and CSS",
       package: package(),
       elixir: "~> 1.2",
@@ -33,7 +33,8 @@ defmodule StripJs.Mixfile do
 
   defp deps do
     [
-      {:floki, "~> 0.17.2"},
+      {:floki, "~> 0.21.0"},
+      {:html_entities, "~> 0.4"},
       {:ex_spec, "~> 2.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, ">= 0.0.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,12 @@
-%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], []},
-  "floki": {:hex, :floki, "0.17.2", "81b3a39d85f5cae39c8da16236ce152f7f8f50faf84b480ba53351d7e96ca6ca", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
-  "html_entities": {:hex, :html_entities, "0.3.0", "2f278ffc69c3f0cbd5996628fef37cf922fa715f3e04b9f38924c8adced3f25a", [], [], "hexpm"},
-  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []}}
+%{
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm"},
+  "floki": {:hex, :floki, "0.21.0", "0c0191a6dbc559300bac232f716c55fb5738d45ae846b3141b19e5f5741c1907", [:mix], [{:html_entities, "~> 0.4.0", [hex: :html_entities, repo: "hexpm", optional: false]}, {:mochiweb, "~> 2.15", [hex: :mochiweb, repo: "hexpm", optional: false]}], "hexpm"},
+  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "mochiweb": {:hex, :mochiweb, "2.18.0", "eb55f1db3e6e960fac4e6db4e2db9ec3602cc9f30b86cd1481d56545c3145d2e", [:rebar3], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+}

--- a/test/strip_js_test.exs
+++ b/test/strip_js_test.exs
@@ -82,7 +82,7 @@ defmodule StripJsTest do
       assert("<tt>&lt;</tt>" == StripJs.clean_html("<tt>&lt;</tt>"))
       assert("<tt attr=\"&lt;\">&lt;</tt>" == StripJs.clean_html("<tt attr='<'><</tt>"))
       assert("<tt attr=\"&lt;\">&lt;</tt>" == StripJs.clean_html("<tt attr='&lt;'>&lt;</tt>"))
-      assert("&lt;script&gt; alert('pwnt'); &lt;/script&gt;" == StripJs.clean_html("&lt;script&gt; alert('pwnt'); &lt;/script&gt;"))
+      assert("&lt;script&gt; alert(&apos;pwnt&apos;); &lt;/script&gt;" == StripJs.clean_html("&lt;script&gt; alert('pwnt'); &lt;/script&gt;"))
     end
   end
 


### PR DESCRIPTION
In updating floki to latest 0.21 it appears encoding html entities is automatic though doesn't work for all use cases in strip_js (a few failing doctests for HTML entity attacks).  So I just referenced HtmlEntities (used by floki) directly.

I also added a PR to html_entities to handle double encoding via `encode_once` though I'm not sure if that is desired.
https://github.com/martinsvalin/html_entities/pull/15

Haven't used StripJs yet so looking for thoughts.
