### PR TITLE
StripJs 0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+
+jobs:
+  build:
+    parallelism: 1
+    docker:
+      - image: circleci/elixir:1.10.1
+        environment:
+          MIX_ENV: test
+
+    working_directory: ~/app
+
+    steps:
+      - checkout
+
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+
+      - restore_cache:
+          keys:
+            - v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v1-mix-cache-{{ .Branch }}
+            - v1-mix-cache
+      - restore_cache:
+          keys:
+            - v1-build-cache-{{ .Branch }}
+            - v1-build-cache
+      - run: mix do deps.get, compile
+      - save_cache:
+          key: v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          paths: "deps"
+      - save_cache:
+          key: v1-build-cache-{{ .Branch }}
+          paths: "_build"
+
+      - run: mix format --check-formatted
+      - run: mix test
+
+      - store_test_results:
+          # Read more: https://circleci.com/docs/2.0/collect-test-data/
+          path: _build/test/lib/customer_api # Replace with the name of your :app
+

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["mix.exs", "{config,lib,priv,test,web}/**/*.{ex,exs}"],
+  line_length: 80
+]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # StripJs
 
+[![appcues](https://circleci.com/gh/appcues/strip_js.svg?style=svg)](https://circleci.com/gh/appcues/strip_js)
+[![StripJs version](https://img.shields.io/hexpm/v/strip_js.svg)](https://hex.pm/packages/strip_js)
+[![Hex.pm](https://img.shields.io/hexpm/dt/strip_js.svg)](https://hex.pm/packages/strip_js)
+
 StripJs is an Elixir module for stripping executable JavaScript from
 blocks of HTML and CSS.
 
@@ -35,7 +39,7 @@ Hexdocs.pm.
 
 ## Authorship and License
 
-Copyright 2017, Appcues, Inc.
+Copyright 2020, Appcues, Inc.
 
 StripJs is released under the
 [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/strip_js.ex
+++ b/lib/strip_js.ex
@@ -1,5 +1,5 @@
 defmodule StripJs do
-  @moduledoc ~s"""
+  @moduledoc ~S"""
   StripJs is an Elixir module for stripping executable JavaScript from
   blocks of HTML and CSS.
 
@@ -21,10 +21,8 @@ defmodule StripJs do
       end
 
       def deps do
-        [{:strip_js, "~> #{StripJs.Mixfile.project[:version]}"}]
+        [{:strip_js, "~> #{StripJs.Mixfile.project()[:version]}"}]
       end
-
-  """ <> ~S"""
 
   ## Usage
 
@@ -44,7 +42,7 @@ defmodule StripJs do
   HTML parser library, which is built using
   [Mochiweb](https://github.com/mochi/mochiweb).
   StripJs provides a `clean_html_tree/1` function to strip JS from
-  `Floki.parse/1`- and `:mochiweb_html.parse/1`- style HTML parse trees.
+  `Floki.parse_fragment/1`- and `:mochiweb_html.parse/1`- style HTML parse trees.
 
 
   ## Bugs and Limitations
@@ -61,7 +59,7 @@ defmodule StripJs do
 
   ## Authorship and License
 
-  Copyright 2017, Appcues, Inc.
+  Copyright 2020, Appcues, Inc.
 
   Project homepage:
   [StripJs](https://github.com/appcues/strip_js)
@@ -71,16 +69,16 @@ defmodule StripJs do
   """
   require Logger
 
-  @type opts :: Keyword.t  # reserved for future use
+  # reserved for future use
+  @type opts :: Keyword.t()
 
-  @type html_tag :: String.t
+  @type html_tag :: String.t()
 
-  @type html_attr :: {String.t, String.t}
+  @type html_attr :: {String.t(), String.t()}
 
-  @type html_node :: String.t | {html_tag, [html_attr], [html_node]}
+  @type html_node :: String.t() | {html_tag, [html_attr], [html_node]}
 
   @type html_tree :: html_node | [html_node]
-
 
   @doc ~S"""
   Removes JS vectors from the given HTML string.
@@ -102,7 +100,7 @@ defmodule StripJs do
       iex> StripJs.clean_html("&lt;script&gt; console.log('oh heck'); &lt;/script&gt;")
       "&lt;script&gt; console.log('oh heck'); &lt;/script&gt;"  ## HTML entity attack didn't work
   """
-  @spec clean_html(String.t, opts) :: String.t
+  @spec clean_html(String.t(), opts) :: String.t()
   def clean_html(html, opts \\ []) when is_binary(html) do
     html
     |> parse_html(opts)
@@ -115,7 +113,6 @@ defmodule StripJs do
     IO.warn("StripJs.strip_js is deprecated; use StripJs.clean_html instead")
     clean_html(html, opts)
   end
-
 
   @doc ~S"""
   Removes JS vectors from the given
@@ -130,7 +127,7 @@ defmodule StripJs do
   def clean_html_tree(trees, opts \\ [])
 
   def clean_html_tree(trees, opts) when is_list(trees) do
-    Enum.map(trees, &(clean_html_tree(&1, opts)))
+    Enum.map(trees, &clean_html_tree(&1, opts))
   end
 
   def clean_html_tree({:comment, comment}, _opts) do
@@ -140,12 +137,17 @@ defmodule StripJs do
   def clean_html_tree({tag, attrs, children}, _opts) do
     case String.downcase(tag) do
       "script" ->
-        ""  # remove scripts entirely
+        # remove scripts entirely
+        ""
+
       "style" ->
-        cleaned_css = children |> to_html |> clean_css  # don't HTML-escape!
+        # don't HTML-escape!
+        cleaned_css = children |> to_html |> clean_css
         {tag, clean_attrs(attrs), [cleaned_css]}
+
       _ ->
-        cleaned_children = Enum.map(children, &(clean_html_tree(&1)))
+        cleaned_children = Enum.map(children, &clean_html_tree(&1))
+
         {tag, clean_attrs(attrs), cleaned_children}
     end
   end
@@ -157,10 +159,12 @@ defmodule StripJs do
   @doc false
   @spec strip_js_from_tree(html_tree, opts) :: html_tree
   def strip_js_from_tree(tree, opts \\ []) do
-    IO.warn("StripJs.strip_js_from_tree is deprecated; use StripJs.clean_html_tree instead")
+    IO.warn(
+      "StripJs.strip_js_from_tree is deprecated; use StripJs.clean_html_tree instead"
+    )
+
     clean_html_tree(tree, opts)
   end
-
 
   @doc ~S"""
   Removes JS vectors from the given CSS string; i.e., the contents of a
@@ -179,40 +183,46 @@ defmodule StripJs do
   possible for innocent CSS containing either of the strings `javascript:`
   or `expression(` to be mangled.
   """
-  @spec clean_css(String.t, opts) :: String.t
+  @spec clean_css(String.t(), opts) :: String.t()
   def clean_css(css, _opts \\ []) when is_binary(css) do
     css
     |> String.replace(~r/javascript \s* :/xi, "removed_by_strip_js:")
     |> String.replace(~r/expression \s* \(/xi, "removed_by_strip_js(")
   end
 
-
   ## Removes JS vectors from the given HTML attributes.
-  @spec clean_attrs([{String.t, String.t}]) :: [{String.t, String.t}]
+  @spec clean_attrs([{String.t(), String.t()}]) :: [{String.t(), String.t()}]
   defp clean_attrs(attrs) do
     attrs
     |> Enum.reduce([], &clean_attr/2)
-    |> Enum.reverse
+    |> Enum.reverse()
   end
 
   @attrs_with_urls ["href", "src", "background", "dynsrc", "lowsrc"]
 
-  @spec clean_attr({String.t, String.t}, [{String.t, String.t}]) :: [{String.t, String.t}]
+  @spec clean_attr({String.t(), String.t()}, [{String.t(), String.t()}]) :: [
+          {String.t(), String.t()}
+        ]
   defp clean_attr({attr, value}, acc) do
     attr = String.downcase(attr)
+
     cond do
-      (attr in @attrs_with_urls) && String.match?(value, ~r/^ \s* javascript \s* :/xi) ->
-        [{attr, "#"} | acc]  # retain the attribute so we emit valid HTML
+      attr in @attrs_with_urls &&
+          String.match?(value, ~r/^ \s* javascript \s* :/xi) ->
+        # retain the attribute so we emit valid HTML
+        [{attr, "#"} | acc]
+
       String.starts_with?(attr, "on") ->
-        acc  # remove on* handlers entirely
+        # remove on* handlers entirely
+        acc
+
       :else ->
-        [{attr, value |> escape_quotes |> html_escape} | acc]
+        [{attr, value} | acc]
     end
   end
 
-
   ## Performs good-enough HTML escaping to prevent HTML entity attacks.
-  @spec html_escape(String.t) :: String.t
+  @spec html_escape(String.t()) :: String.t()
   defp html_escape(html) do
     html
     |> String.replace("&", "&amp;")
@@ -225,15 +235,12 @@ defmodule StripJs do
     |> String.replace("\"", "&quot;")
   end
 
-
   ## Parses the given HTML into an `t:html_tree/0` structure.
-  @spec parse_html(String.t, opts) :: html_tree
-  defp parse_html(html, _opts), do: Floki.parse(html)
-
+  @spec parse_html(String.t(), opts) :: html_tree
+  defp parse_html(html, _opts), do: Floki.parse_fragment!(html)
 
   ## Converts HTML tree to string.
-  @spec to_html(html_tree) :: String.t
+  @spec to_html(html_tree) :: String.t()
   defp to_html(tree) when is_binary(tree), do: tree
-  defp to_html(tree), do: tree |> Floki.raw_html
+  defp to_html(tree), do: tree |> Floki.raw_html(encode: false)
 end
-

--- a/lib/strip_js.ex
+++ b/lib/strip_js.ex
@@ -230,11 +230,6 @@ defmodule StripJs do
     |> String.replace(">", "&gt;")
   end
 
-  defp escape_quotes(html) do
-    html
-    |> String.replace("\"", "&quot;")
-  end
-
   ## Parses the given HTML into an `t:html_tree/0` structure.
   @spec parse_html(String.t(), opts) :: html_tree
   defp parse_html(html, _opts), do: Floki.parse_fragment!(html)

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule StripJs.Mixfile do
 
   defp deps do
     [
-      {:floki, github: "appcues/floki", ref: "0bf9762"},
+      {:floki, github: "philss/floki", ref: "af5dcdb"},
       {:ex_spec, "~> 2.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, ">= 0.0.0", only: :dev}

--- a/mix.exs
+++ b/mix.exs
@@ -4,40 +4,39 @@ defmodule StripJs.Mixfile do
   def project do
     [
       app: :strip_js,
-      version: "0.9.2",
+      version: "0.10.0",
       description: "Strip JavaScript from HTML and CSS",
       package: package(),
-      elixir: "~> 1.2",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      elixir: "~> 1.10",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: [
-        docs: "docs --source-url https://github.com/appcues/strip_js",
-      ],
-   ]
+        docs: "docs --source-url https://github.com/appcues/strip_js"
+      ]
+    ]
   end
 
   def package do
     [
       licenses: ["MIT"],
       maintainers: ["pete gamache <pete@appcues.com>"],
-      links: %{github: "https://github.com/appcues/strip_js"},
+      links: %{github: "https://github.com/appcues/strip_js"}
     ]
   end
 
   def application do
     [
-      applications: [:logger, :floki],
+      applications: [:logger, :floki]
     ]
   end
 
   defp deps do
     [
-      {:floki, "~> 0.17.2"},
+      {:floki, github: "appcues/floki", ref: "0bf9762"},
       {:ex_spec, "~> 2.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:dialyxir, ">= 0.0.0", only: :dev},
+      {:dialyxir, ">= 0.0.0", only: :dev}
     ]
   end
 end
-

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,12 @@
-%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], []},
-  "floki": {:hex, :floki, "0.17.2", "81b3a39d85f5cae39c8da16236ce152f7f8f50faf84b480ba53351d7e96ca6ca", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
-  "html_entities": {:hex, :html_entities, "0.3.0", "2f278ffc69c3f0cbd5996628fef37cf922fa715f3e04b9f38924c8adced3f25a", [], [], "hexpm"},
-  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []}}
+%{
+  "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "0db1ee8d1547ab4877c5b5dffc6604ef9454e189928d5ba8967d4a58a801f161"},
+  "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm", "b44fe5054497411a58341ece5bf7756c219d9d6c1303b5ac467f557a0a4c31ac"},
+  "floki": {:git, "https://github.com/appcues/floki.git", "0bf976219e4836ba039fed201536ad3bab83b085", [ref: "0bf9762"]},
+  "html_entities": {:hex, :html_entities, "0.5.1", "1c9715058b42c35a2ab65edc5b36d0ea66dd083767bef6e3edb57870ef556549", [:mix], [], "hexpm", "30efab070904eb897ff05cd52fa61c1025d7f8ef3a9ca250bc4e6513d16c32de"},
+  "makeup": {:hex, :makeup, "1.0.1", "82f332e461dc6c79dbd82fbe2a9c10d48ed07146f0a478286e590c83c52010b5", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "49736fe5b66a08d8575bf5321d716bac5da20c8e6b97714fec2bcd6febcfa1f8"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "0db1ee8d1547ab4877c5b5dffc6604ef9454e189928d5ba8967d4a58a801f161"},
   "ex_spec": {:hex, :ex_spec, "2.0.1", "8bdbd6fa85995fbf836ed799571d44be6f9ebbcace075209fd0ad06372c111cf", [:mix], [], "hexpm", "b44fe5054497411a58341ece5bf7756c219d9d6c1303b5ac467f557a0a4c31ac"},
-  "floki": {:git, "https://github.com/appcues/floki.git", "0bf976219e4836ba039fed201536ad3bab83b085", [ref: "0bf9762"]},
+  "floki": {:git, "https://github.com/philss/floki.git", "af5dcdbf1d2f58559b6b6abc8a796deed7090362", [ref: "af5dcdb"]},
   "html_entities": {:hex, :html_entities, "0.5.1", "1c9715058b42c35a2ab65edc5b36d0ea66dd083767bef6e3edb57870ef556549", [:mix], [], "hexpm", "30efab070904eb897ff05cd52fa61c1025d7f8ef3a9ca250bc4e6513d16c32de"},
   "makeup": {:hex, :makeup, "1.0.1", "82f332e461dc6c79dbd82fbe2a9c10d48ed07146f0a478286e590c83c52010b5", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "49736fe5b66a08d8575bf5321d716bac5da20c8e6b97714fec2bcd6febcfa1f8"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,56 +6,55 @@ defmodule TestCases do
     },
     {
       ~s[<a href="whatever" onclick="alert('XSS');">Click here</a>],
-      ~s[<a href="whatever">Click here</a>],
+      ~s[<a href="whatever">Click here</a>]
     },
     {
       ~s[<body onload="alert('XSS')"><p>Hello</p></body>],
-      ~s[<body><p>Hello</p></body>],
+      ~s[<body><p>Hello</p></body>]
     },
     {
       ~s[<img src="javascript:alert('XSS');">],
-      ~s[<img src="#"/>],
+      ~s[<img src="#"/>]
     },
     {
       ~s[<script>alert('XSS');</script>],
-      ~s[],
+      ~s[]
     },
     {
       ~s[<body background="javascript:alert('XSS');"><p>Hello</p></body>],
-      ~s[<body background="#"><p>Hello</p></body>],
+      ~s[<body background="#"><p>Hello</p></body>]
     },
     {
       ~s[<style>body { background-image: expression('alert("XSS")'); }</style>],
-      ~s[<style>body { background-image: removed_by_strip_js('alert("XSS")'); }</style>],
+      ~s[<style>body { background-image: removed_by_strip_js('alert("XSS")'); }</style>]
     },
     {
       ~s[<style>body { background-image: url('javascript:alert("XSS")'); }</style>],
-      ~s[<style>body { background-image: url('removed_by_strip_js:alert("XSS")'); }</style>],
+      ~s[<style>body { background-image: url('removed_by_strip_js:alert("XSS")'); }</style>]
     },
     {
       ~s[<style><script>alert('XSS')</script></style>],
-      ~s[<style><script>alert('XSS')</script></style>],
+      ~s[<style><script>alert('XSS')</script></style>]
     },
     {
       ~s[<style> h1 > a { color: red; } </style>],
-      ~s[<style> h1 > a { color: red; } </style>],
+      ~s[<style> h1 > a { color: red; } </style>]
     },
     {
       ~s[<],
-      ~s[&lt;],
+      ~s[&lt;]
     },
     {
       ~s[>],
-      ~s[&gt;],
+      ~s[&gt;]
     },
     {
       ~s[],
-      ~s[],
-    },
+      ~s[]
+    }
   ]
 
   def test_cases, do: @test_cases
 end
 
 ExUnit.start()
-


### PR DESCRIPTION
0.10.0 does more than a few things:
- runs `mix format` on the project, adding `.formatter.exs`
- adds CircleCI for running the formatter as well as `mix test`
- updates Floki to `0.26.x`, pending a patch I made for Floki here:
  philss/floki#270
    - with the Floki update, switch to use `parse_fragment!/1` instead
      of the now deprecated `Floki.parse`
- updates README and adds badges for hex/circle